### PR TITLE
use mars default types

### DIFF
--- a/definitions/grib2/local.215.def
+++ b/definitions/grib2/local.215.def
@@ -49,7 +49,7 @@ concept marsType(unknown) {
       typeOfGeneratingProcess = 0;
       backgroundProcess = 2;
     }
-    ia = {
+    fg = {
       typeOfGeneratingProcess = 2;
       backgroundProcess = 0;
     }

--- a/definitions/grib2/local.215.def
+++ b/definitions/grib2/local.215.def
@@ -14,6 +14,11 @@ concept marsStream(unknown) {
     enda = {
       typeOfGeneratingProcess = 0;
       backgroundProcess = 2;}
+    # fg
+    enda = {
+      typeOfGeneratingProcess = 2;
+      backgroundProcess = 0;
+    }
     # ... analysis increment (to be defined)
     # ... initialized analysis (to be defined)
     # ... first guess det (to be defined)
@@ -39,6 +44,16 @@ concept marsType(unknown) {
     #     (discipline, parameterCategory, parameterNumber), and chemical constituent
     det = {
       productDefinitionTemplateNumber = 42;}
+    
+    an = {
+      typeOfGeneratingProcess = 0;
+      backgroundProcess = 2;
+    }
+    ia = {
+      typeOfGeneratingProcess = 2;
+      backgroundProcess = 0;
+    }
+    
     # ensemble forecast or assimilation product, perturbed or control member 
     # (a new type could be used for each productDefinitionTemplateNumber)
     # ... instantaneous value

--- a/definitions/grib2/local.215.def
+++ b/definitions/grib2/local.215.def
@@ -42,24 +42,44 @@ concept marsType(unknown) {
     # ensemble forecast or assimilation product, perturbed or control member 
     # (a new type could be used for each productDefinitionTemplateNumber)
     # ... instantaneous value
-    ememb = {
-      productDefinitionTemplateNumber = 1;}
+    cf = {
+      productDefinitionTemplateNumber = 1;
+      perturbationNumber = 0; }
+    pf = {
+      productDefinitionTemplateNumber = 1;
+    }
     # ... instantaneous value, chemical constituent
-    ememb = {
-      productDefinitionTemplateNumber = 41;}
+    cf = {
+      productDefinitionTemplateNumber = 41;
+      perturbationNumber = 0; 
+    }
+    pf = {
+      productDefinitionTemplateNumber = 41;
+    }
     # ... temporal accumulation
-    ememb = {
-      productDefinitionTemplateNumber = 11;}
+    cf = {
+      productDefinitionTemplateNumber = 11;
+      perturbationNumber = 0; 
+    }
+    pf = {
+      productDefinitionTemplateNumber = 11;
+    }
     # ... temporal accumulation, chemical constituent
-    ememb = {
-      productDefinitionTemplateNumber = 43;}
+    cf = {
+      productDefinitionTemplateNumber = 43;
+      perturbationNumber = 0; 
+    }
+    pf = {
+      productDefinitionTemplateNumber = 43;
+    }
     # derived forecast
     # ... instantaneous value, unweighted ensemble mean
-    emean = {
+    em = {
       productDefinitionTemplateNumber = 2;
       derivedForecast = 0;}
+
     # ... instantaneous value, unweighted ensemble standard deviation
-    estdv = {
+    es = {
       productDefinitionTemplateNumber = 2;
       derivedForecast = 4;}
 } : no_copy;

--- a/definitions/grib2/local.215.def
+++ b/definitions/grib2/local.215.def
@@ -31,18 +31,18 @@ concept marsType(unknown) {
     # deterministic forecast or assimilation product
     # # (a new type could be used for each productDefinitionTemplateNumber)
     # ... instantaneous value
-    det = {
+    fc = {
       productDefinitionTemplateNumber = 0;}
     # ... instantaneous value, chemical constituent
-    det = {
+    fc = {
       productDefinitionTemplateNumber = 40;}
     # ... temporal accumulation
-    det = {
+    fc = {
       productDefinitionTemplateNumber = 8;}
     # ... temporal accumulation, chemical constituent
     #     COSMO and ICON define a unique parameter id for each combination of 
     #     (discipline, parameterCategory, parameterNumber), and chemical constituent
-    det = {
+    fc = {
       productDefinitionTemplateNumber = 42;}
     
     an = {

--- a/definitions/mars/grib.enfo.ememb.def
+++ b/definitions/mars/grib.enfo.ememb.def
@@ -1,1 +1,0 @@
-alias mars.number = perturbationNumber;


### PR DESCRIPTION
Originally the idea of creating a new ememb, was to cluster the control with the perturbed in the same type. However, we changed that decision in favour of following more the default types of mars where cf and pf are separated. 
Additionally in the PR we attempt:
* consider iaf files in the enda stream
* define the types for our an (analysis) and first guess 