### PR TITLE
set cape to sfc

### DIFF
--- a/definitions/grib2/marsLevtypeConcept.def
+++ b/definitions/grib2/marsLevtypeConcept.def
@@ -63,9 +63,9 @@
 #isobaricLayer
 'pl'   = {typeOfFirstFixedSurface=100; typeOfSecondFixedSurface=1;}
 #atmML
-'ml'   = {typeOfFirstFixedSurface=192; typeOfSecondFixedSurface=255;} 
+'sfc'   = {typeOfFirstFixedSurface=192; typeOfSecondFixedSurface=255;} 
 #atmMU
-'ml'   = {typeOfFirstFixedSurface=193; typeOfSecondFixedSurface=255;} 
+'sfc'   = {typeOfFirstFixedSurface=193; typeOfSecondFixedSurface=255;} 
 #thermocline
 'ml'   = {typeOfFirstFixedSurface=166; typeOfSecondFixedSurface=162;} 
 #cloudBase


### PR DESCRIPTION
CAPE_ML, CAPE_MU (as well as CIN_ML, CIN_MU) are defined with 
typeOfFirstFixedSurface=192, typeOfSecondFixedSurface=255
typeOfFirstFixedSurface=193, typeOfSecondFixedSurface=255
The values 192, and 193 are local definitions (not globally defined in GRIB). 
But these variables (after discussions with Marco) should be considered as a sfc, much like CLCT (represent a total over the atmosphere)