### PR TITLE
add timespanConcept

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # eccodes-cosmo-mars
 mars definitions for cosmo operational data at MeteoSwiss
+
+Note:
+* Concepts in the directory `definitions/grib2/` are *global* concepts, i.e., *replace* the concepts of eccodes, or do not have an effect depending on the order the resources are specified in `GRIB_DEFINITION_PATH` / `ECCODES_DEFINITION_PATH`.
+* Concepts in the directory `definitions/grib2/localConcepts/<centre>/` are *additive* to the global concepts (from eccodes or `definitions/grib2/`), and only apply for the respective `<centre>`.

--- a/definitions/grib2/localConcepts/lssw/timespanConcept.def
+++ b/definitions/grib2/localConcepts/lssw/timespanConcept.def
@@ -9,7 +9,7 @@
 
 # mean (typeOfStatisticalProcessing=0), since start:
 'fromstart' = {typeOfStatisticalProcessing=0; forecastTime=0;
-               true=is_one_of(paramId, 500078, 500080, 500086, 500087, 500088, 500089, 500480, 500481, 500482, 503135, 503174, 503307, 503601);}
+               true=is_one_of(paramId, 500078, 500080, 500086, 500087, 500088, 500089, 500480, 500481, 500482, 503135, 503174, 503307, 503601, 503750, 503752, 503756);}
 
 # summation (typeOfStatisticalProcessing=11), since start:
 'fromstart' = {typeOfStatisticalProcessing=11; forecastTime=0; paramId=503167;}

--- a/definitions/grib2/localConcepts/lssw/timespanConcept.def
+++ b/definitions/grib2/localConcepts/lssw/timespanConcept.def
@@ -1,0 +1,19 @@
+## Statistical window concept for MeteoSwiss (lssw)
+# Extension of eccodes/definitions/grib2/timespanConcept.def
+# (https://github.com/ecmwf/eccodes/blob/develop/definitions/grib2/timespanConcept.def)
+#
+# Concept evaluation: * the rule with the most matching conditions wins
+#                     * for equal score, the first rule wins
+#
+
+
+# step 0: lengthOfTimeRange=0 -> 'none'?
+'none' = {typeOfStatisticalProcessing=0;  forecastTime=0; indicatorOfUnitForTimeRange=0; lengthOfTimeRange=0;}
+'none' = {typeOfStatisticalProcessing=11; forecastTime=0; indicatorOfUnitForTimeRange=0; lengthOfTimeRange=0;}
+
+# mean (typeOfStatisticalProcessing=0), since start:
+'fromstart' = {typeOfStatisticalProcessing=0; forecastTime=0;
+               true=is_one_of(paramId, 500078, 500080, 500086, 500087, 500088, 500089, 500480, 500481, 500482, 503135, 503174, 503307, 503601);}
+
+# summation (typeOfStatisticalProcessing=11), since start:
+'fromstart' = {typeOfStatisticalProcessing=11; forecastTime=0; paramId=503167;}

--- a/definitions/grib2/localConcepts/lssw/timespanConcept.def
+++ b/definitions/grib2/localConcepts/lssw/timespanConcept.def
@@ -13,3 +13,9 @@
 
 # summation (typeOfStatisticalProcessing=11), since start:
 'fromstart' = {typeOfStatisticalProcessing=11; forecastTime=0; paramId=503167;}
+
+
+# also determine longer time spans based on minutes
+'3h'  = {indicatorOfUnitForTimeRange=0; lengthOfTimeRange = 180;}
+'6h'  = {indicatorOfUnitForTimeRange=0; lengthOfTimeRange = 360;}
+'12h' = {indicatorOfUnitForTimeRange=0; lengthOfTimeRange = 720;}

--- a/definitions/grib2/localConcepts/lssw/timespanConcept.def
+++ b/definitions/grib2/localConcepts/lssw/timespanConcept.def
@@ -3,13 +3,9 @@
 # (https://github.com/ecmwf/eccodes/blob/develop/definitions/grib2/timespanConcept.def)
 #
 # Concept evaluation: * the rule with the most matching conditions wins
-#                     * for equal score, the first rule wins
+#                     * for equal score, the first rule in the file wins
 #
 
-
-# step 0: lengthOfTimeRange=0 -> 'none'?
-'none' = {typeOfStatisticalProcessing=0;  forecastTime=0; indicatorOfUnitForTimeRange=0; lengthOfTimeRange=0;}
-'none' = {typeOfStatisticalProcessing=11; forecastTime=0; indicatorOfUnitForTimeRange=0; lengthOfTimeRange=0;}
 
 # mean (typeOfStatisticalProcessing=0), since start:
 'fromstart' = {typeOfStatisticalProcessing=0; forecastTime=0;


### PR DESCRIPTION
Additions to the timespanConcept for realtime data.

- Right now, the timespan is determined based on `paramId`, is this necessary or can we apply more general rules?
- `timespan=fs` is applied to *all* steps, including step 0. This is aligned with how the global concept handles accumulations (`typeOfStatisticalProcessing=1`).
  However: rolling windows use 'none' for step 0 and e.g. '1h' for subsequent steps (see global concept)!
- Should we add a catch-it-all `'none' = {true=1;}`? This would then align with [MARS-007](https://github.com/ecmwf/codex/blob/main/MARS%20language/MARS-007-Timespan-Absence.md#option-comparison-grid), where for Option 3 a timespan keyword is mandatory on archival.