### PR TITLE
Varda ext

### DIFF
--- a/definitions/grib2/local.215.def
+++ b/definitions/grib2/local.215.def
@@ -19,36 +19,57 @@ concept marsClass(unknown) {
   'rd' = {
     generatingProcessIdentifier = 170;
   }
+  # VARDA-SINGLE: research data when localNumberOfExperiment=900, operational otherwise
+  'rd' = {
+    localNumberOfExperiment = 0;
+    generatingProcessIdentifier = 180;
+  }
+  'ai' = {
+    generatingProcessIdentifier = 180;
+  }
 } : no_copy;
 
 concept marsStream(unknown) {
+    reanl = {
+      generatingProcessIdentifier = 170;
+    }
+
     # Ensemble data assimilation system
     # ... uninitialized analysis
     enda = {
       typeOfGeneratingProcess = 0;
-      backgroundProcess = 2;}
+      backgroundProcess = 2;
+      generatingProcessIdentifier = 121;
+    }
     # fg
     enda = {
       typeOfGeneratingProcess = 2;
       backgroundProcess = 0;
+      generatingProcessIdentifier = 121; 
     }
+    oper = {
+      productDefinitionTemplateNumber = 0;
+      # Forecast
+      typeOfProcessedData = 1; 
+    }
+    oper = {
+      productDefinitionTemplateNumber = 8;
+      # Forecast
+      typeOfProcessedData = 1; 
+    }
+
     # ... analysis increment (to be defined)
     # ... initialized analysis (to be defined)
     # ... first guess det (to be defined)
     # ensemble forecast
     enfo = {
       typeOfGeneratingProcess = 4;
-      generatingProcessIdentifier = 141;
+      productDefinitionTemplateNumber  = 1;
     }
     enfo = {
       typeOfGeneratingProcess = 4;
-      generatingProcessIdentifier = 142;
+      productDefinitionTemplateNumber  = 11;
     }
-
-    reanl = {
-      generatingProcessIdentifier = 170;
-    }
-
 } : no_copy;
 
 concept marsType(unknown) {
@@ -73,6 +94,7 @@ concept marsType(unknown) {
       typeOfGeneratingProcess = 0;
       backgroundProcess = 2;
     }
+
     fg = {
       typeOfGeneratingProcess = 2;
       backgroundProcess = 0;
@@ -167,7 +189,22 @@ concept marsModel(unknown) {
     'ICON-REA-L-CH1' = {
       generatingProcessIdentifier = 170;}
     'VARDA-SINGLE' = {
-      generatingProcessIdentifier = 180;}
+      generatingProcessIdentifier = 180;
+      productDefinitionTemplateNumber = 0;
+    }
+    'VARDA-SINGLE' = {
+      generatingProcessIdentifier = 180;
+      productDefinitionTemplateNumber = 8;
+    }
+    'VARDA-ENS' = {
+      generatingProcessIdentifier = 180;
+      productDefinitionTemplateNumber = 1;
+    }
+    'VARDA-ENS' = {
+      generatingProcessIdentifier = 180;
+      productDefinitionTemplateNumber = 11;
+    }
+
 } : no_copy;
 
 

--- a/definitions/grib2/local.215.def
+++ b/definitions/grib2/local.215.def
@@ -32,6 +32,7 @@ concept marsClass(unknown) {
 concept marsStream(unknown) {
     reanl = {
       generatingProcessIdentifier = 170;
+      typeOfGeneratingProcess = 4;
     }
 
     # Ensemble data assimilation system

--- a/definitions/grib2/local.215.def
+++ b/definitions/grib2/local.215.def
@@ -59,17 +59,46 @@ concept marsStream(unknown) {
       typeOfProcessedData = 1; 
     }
 
-    # ... analysis increment (to be defined)
-    # ... initialized analysis (to be defined)
-    # ... first guess det (to be defined)
-    # ensemble forecast
+# ensemble forecast
     enfo = {
       typeOfGeneratingProcess = 4;
-      productDefinitionTemplateNumber  = 1;
+      productDefinitionTemplateNumber = 1;
     }
     enfo = {
       typeOfGeneratingProcess = 4;
-      productDefinitionTemplateNumber  = 11;
+      productDefinitionTemplateNumber = 11;
+    }
+    # ... derived products (mean, spread, ...), point-in-time / accumulation
+    enfo = {
+      typeOfGeneratingProcess = 4;
+      productDefinitionTemplateNumber = 2;
+    }
+    enfo = {
+      typeOfGeneratingProcess = 4;
+      productDefinitionTemplateNumber = 12;
+    }
+    # ... percentile forecasts, point-in-time / accumulation
+    enfo = {
+      typeOfGeneratingProcess = 4;
+      productDefinitionTemplateNumber = 6;
+    }
+    enfo = {
+      typeOfGeneratingProcess = 4;
+      productDefinitionTemplateNumber = 10;
+    }
+    # ... synthetic satellite members
+    enfo = {
+      typeOfGeneratingProcess = 4;
+      productDefinitionTemplateNumber = 33;
+    }
+    # ... chemical constituent members, point-in-time / accumulation
+    enfo = {
+      typeOfGeneratingProcess = 4;
+      productDefinitionTemplateNumber = 41;
+    }
+    enfo = {
+      typeOfGeneratingProcess = 4;
+      productDefinitionTemplateNumber = 43;
     }
 } : no_copy;
 

--- a/definitions/grib2/local.215.def
+++ b/definitions/grib2/local.215.def
@@ -81,10 +81,14 @@ concept marsType(unknown) {
     fc = {
       productDefinitionTemplateNumber = 0;
       typeOfGeneratingProcess = 2;
-      backgroundProcess = 0;}
+      backgroundProcess = 0;
+    }
     # ... instantaneous value, chemical constituent
     fc = {
-      productDefinitionTemplateNumber = 40;}
+      productDefinitionTemplateNumber = 40;
+      typeOfGeneratingProcess = 2;
+      backgroundProcess = 0;
+    }
     # ... temporal accumulation (deterministic)
     fc = {
       productDefinitionTemplateNumber = 8;
@@ -94,7 +98,10 @@ concept marsType(unknown) {
     #     COSMO and ICON define a unique parameter id for each combination of
     #     (discipline, parameterCategory, parameterNumber), and chemical constituent
     fc = {
-      productDefinitionTemplateNumber = 42;}
+      productDefinitionTemplateNumber = 42;
+      typeOfGeneratingProcess = 2;
+      backgroundProcess = 0;
+    }
 
     an = {
       typeOfGeneratingProcess = 0;

--- a/definitions/grib2/local.215.def
+++ b/definitions/grib2/local.215.def
@@ -19,7 +19,7 @@ concept marsClass(unknown) {
   'rd' = {
     generatingProcessIdentifier = 170;
   }
-  # VARDA-SINGLE: research data when localNumberOfExperiment=900, operational otherwise
+  # VARDA-SINGLE: research data when localNumberOfExperiment=0, operational otherwise
   'rd' = {
     localNumberOfExperiment = 0;
     generatingProcessIdentifier = 180;

--- a/definitions/grib2/local.215.def
+++ b/definitions/grib2/local.215.def
@@ -75,15 +75,21 @@ concept marsStream(unknown) {
 concept marsType(unknown) {
     # deterministic forecast or assimilation product
     # # (a new type could be used for each productDefinitionTemplateNumber)
-    # ... instantaneous value
+    # ... instantaneous value (deterministic: TOGP=2, backgroundProcess=0)
+    # These rules have 3 keys so they beat the generic fg rule (2 keys) in
+    # eccodes concept matching (most-specific wins).
     fc = {
-      productDefinitionTemplateNumber = 0;}
+      productDefinitionTemplateNumber = 0;
+      typeOfGeneratingProcess = 2;
+      backgroundProcess = 0;}
     # ... instantaneous value, chemical constituent
     fc = {
       productDefinitionTemplateNumber = 40;}
-    # ... temporal accumulation
+    # ... temporal accumulation (deterministic)
     fc = {
-      productDefinitionTemplateNumber = 8;}
+      productDefinitionTemplateNumber = 8;
+      typeOfGeneratingProcess = 2;
+      backgroundProcess = 0;}
     # ... temporal accumulation, chemical constituent
     #     COSMO and ICON define a unique parameter id for each combination of
     #     (discipline, parameterCategory, parameterNumber), and chemical constituent

--- a/definitions/grib2/local.98.def
+++ b/definitions/grib2/local.98.def
@@ -53,7 +53,7 @@ if (  ( extraLocalSectionPresent || addExtraLocalSection )  && ! deleteExtraLoca
 # this concept the key is absent for IFS GRIB and FDB raises a "Serious bug:
 # Could not find [model]" error.
 concept marsModel(unknown) {
-    'VARDA-SINGLE' = {
+    'VARDA-SINGLE-G' = {
       generatingProcessIdentifier = 180;
     }
 } : no_copy;

--- a/definitions/grib2/local.98.def
+++ b/definitions/grib2/local.98.def
@@ -1,0 +1,66 @@
+# local section ECMWF — MeteoSwiss extended version
+#
+# This file overrides grib2/local.98.def to add VARDA-SINGLE (GPI=180) MARS
+# namespace support for IFS/ECMWF-format GRIB files.  It is placed in the
+# eccodes-cosmo-mars definitions directory, which is prepended to
+# ECCODES_DEFINITION_PATH so that it takes priority over the system copy.
+#
+# The body below is a verbatim copy of the upstream grib2/local.98.def followed
+# by MeteoSwiss additions.  A direct `include` cannot be used because that would
+# create a circular reference.
+
+template mars_labeling "grib2/mars_labeling.def";
+transient productDefinitionTemplateNumberInternal=-1;
+
+meta localDefinitionNumber local_definition(grib2LocalSectionNumber,
+                                            productDefinitionTemplateNumber,
+                                            productDefinitionTemplateNumberInternal,
+                                            type,
+                                            stream,
+                                            class,
+                                            eps,
+                                            stepType,
+                                            derivedForecast);
+
+meta eps g2_eps(productDefinitionTemplateNumber,
+                type,
+                stream,
+                stepType,
+                derivedForecast);
+
+template_nofail  localSection  "grib2/local.98.[grib2LocalSectionNumber:l].def";
+position offsetAfterLocalSection;
+transient addExtraLocalSection=0;
+transient deleteExtraLocalSection=0;
+meta extraLocalSectionPresent evaluate (section2Length - offsetAfterLocalSection + offsetSection2 > 0 );
+if (  ( extraLocalSectionPresent || addExtraLocalSection )  && ! deleteExtraLocalSection) {
+    # extra local section present
+    codetable[2] extraLocalSectionNumber 'grib2/grib2LocalSectionNumber.[centreForLocal:l].table' = 300 : dump;
+    template  localSection  "grib2/local.98.[extraLocalSectionNumber:l].def";
+}
+
+#------------------------------------------------------------------------------------
+# MeteoSwiss additions: VARDA-SINGLE (generatingProcessIdentifier=180) support
+# for IFS/ECMWF-format (centre=98) GRIB files.
+#
+# These concepts add mars.model and override mars.stream so that VARDA-SINGLE
+# global-grid output is stored consistently with ICON-grid output under the same
+# FDB stream/model keys.
+#------------------------------------------------------------------------------------
+
+# marsModel: maps GPI=180 to 'VARDA-SINGLE'.
+# The FDB realtime.schema requires the 'model' key in the MARS namespace; without
+# this concept the key is absent for IFS GRIB and FDB raises a "Serious bug:
+# Could not find [model]" error.
+concept marsModel(unknown) {
+    'VARDA-SINGLE' = {
+      generatingProcessIdentifier = 180;
+    }
+} : no_copy;
+
+alias mars.model = marsModel;
+
+# marsStream: The native marsStream codetable key is set to 'enfo' directly in
+# the GRIB encoding (output config), so g2_mars_labeling correctly computes
+# stream='enfo'.  Redefining marsStream as a concept here would conflict with
+# the codetable key expected by g2_mars_labeling in some eccodes builds.


### PR DESCRIPTION
# Description

Changes required to support Varda: 
* new class for Varda named 'ai' following AIFS ('rd' for experiments)
* add oper in marstream since Varda is a deterministic run (not ensemble) and the mars model so far we mostly designed for ens.
* Adding VARDA-ENS (in addition to VARDA-SINGLE)
* Adding mars class for IFS data as well, since Varda generates global data as well, and the mars model is not defined otherwise

# Test

These are significant changes that could affect the realtime or rea-l-ch1. 
I tried to design it so that the model for those do not change. 
I took 1 full forecast of realtime and rea-l-ch1 and checked: 
class, stream, type, model 
**are the same** as currently used operationally
